### PR TITLE
MediaProvider: Fix insert fail while file saved in sdcard

### DIFF
--- a/src/com/android/providers/media/MediaProvider.java
+++ b/src/com/android/providers/media/MediaProvider.java
@@ -2175,7 +2175,7 @@ public class MediaProvider extends ContentProvider {
         if (!values.containsKey(MediaColumns.DATA)) return;
         try {
             // Sanity check that the requested path actually lives on volume
-            final String volumeName = resolveVolumeName(uri);
+            final String volumeName = resolveVolumeName(uri, values.getAsString(MediaColumns.DATA));
             final Collection<File> allowed = getVolumeScanPaths(volumeName);
             final File actual = new File(values.getAsString(MediaColumns.DATA))
                     .getCanonicalFile();
@@ -2891,6 +2891,19 @@ public class MediaProvider extends ContentProvider {
         final String volumeName = getVolumeName(uri);
         if (MediaStore.VOLUME_EXTERNAL.equals(volumeName)) {
             return MediaStore.VOLUME_EXTERNAL_PRIMARY;
+        } else {
+            return volumeName;
+        }
+    }
+
+    private static @NonNull String resolveVolumeName(@NonNull Uri uri, @NonNull String path) {
+        final String volumeName = getVolumeName(uri);
+        if (MediaStore.VOLUME_EXTERNAL.equals(volumeName)) {
+            if (path != null) {
+                return getVolumeName(new File(path));
+            } else {
+                return MediaStore.VOLUME_EXTERNAL_PRIMARY;
+            }
         } else {
             return volumeName;
         }


### PR DESCRIPTION
While uri inserted with volumeName(external) and file saved
in sdcard, only resolving volumeName from uri could get wrong
volumeName, and insert failed meanwhile.

Test: Create file in sdcard and insert it to MediaProvider.

Change-Id: Ie70240c02916107dd71e53c05b9e11e837561bfd